### PR TITLE
Minor fix to correct the F_OPEN kernel command.

### DIFF
--- a/src/sdos_fat.asm
+++ b/src/sdos_fat.asm
@@ -1148,6 +1148,9 @@ pass_failure    PLP                             ; If failure, just pass the fail
                 RTL
 
 mount           JSL DOS_MOUNT
+                BCS get_directory
+                BRL ret_failure
+                
 
 get_directory   setal
                 JSL DOS_DIROPEN                 ; Get the directory


### PR DESCRIPTION
We need to check if the carry is set after the MOUNT command to ensure that errors are handled.